### PR TITLE
fix(docker): Garante a instalação de dependências no dev container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,3 +6,4 @@ services:
     volumes:
       - .:/app
       - /app/node_modules
+    command: sh -c "bun install && bun run dev --host 0.0.0.0 --port 8080"


### PR DESCRIPTION
Resolve um erro de 'Failed to resolve import' que ocorria no ambiente de desenvolvimento com Docker.

O problema era causado por uma dessincronização entre as dependências instaladas durante o build da imagem e as que o Vite esperava encontrar ao iniciar o servidor.

A solução foi adicionar um `command` ao `docker-compose.yml` que força a execução de `bun install` toda vez que o container é iniciado, garantindo que todas as dependências estejam corretamente instaladas antes do servidor de desenvolvimento ser ativado.