### PR TITLE
fix(calendar): Corrige ReferenceError na página do calendário

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -32,6 +32,16 @@ function Index() {
   const [holidays, setHolidays] = useState<Holiday[]>([]);
 
   const bookedDays = useMemo(() => {
+    const dates = bookings
+      .filter(b => b.teacherConfirmation !== 'NEGADO')
+      .map(b => {
+        const [year, month, day] = b.date.split('-').map(Number);
+        return new Date(year, month - 1, day);
+      });
+    return dates;
+  }, [bookings]);
+
+  const holidayDates = useMemo(() => {
     return holidays.map(h => {
       const [year, month, day] = h.date.split('-').map(Number);
       return new Date(year, month - 1, day);


### PR DESCRIPTION
Este commit resolve um `ReferenceError` que impedia a renderização da página principal de agendamentos (`Index.tsx`).

O erro foi introduzido durante uma refatoração anterior, onde a definição da constante `holidayDates` foi acidentalmente removida, enquanto o código que a utilizava permaneceu.

A correção restaura a definição de `holidayDates`, garantindo que a lista de feriados seja corretamente calculada e passada para o componente de calendário.