### PR TITLE
fix(ui): Melhora o destaque de dias agendados no calendário

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -173,7 +173,7 @@ function Index() {
               }}
               modifiersClassNames={{
                 holiday: "text-red-500",
-                booked: "font-bold text-primary",
+                booked: "bg-brand-blue text-white rounded-full",
               }}
             />
           </div>


### PR DESCRIPTION
Com base no seu feedback, aprimorei o estilo para dias com agendamentos no calendário para maior destaque visual.

Substituí o estilo anterior (apenas texto em negrito) por um círculo com fundo azul (#2b466d) e texto na cor branca, tornando mais fácil a identificação de dias ocupados.