### PR TITLE
Fix: Resolve persistent calendar navigation issue

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -190,7 +190,6 @@ function Index() {
                   caption: "flex justify-center pt-1 relative items-center",
                   caption_label: "text-xl font-medium",
                   nav: "space-x-1 flex items-center",
-                  nav_button: "h-10 w-10 bg-transparent p-0 hover:opacity-100",
                   table: "w-full border-collapse space-y-1",
                   head_row: "flex justify-around",
                   head_cell: "text-muted-foreground rounded-md w-12 font-normal text-lg",


### PR DESCRIPTION
This commit addresses a persistent bug where you could not navigate to past months in the calendar. The issue was traced to custom styling on the navigation buttons that interfered with their layout and functionality.

This fix removes the custom `nav_button` class override from the `Calendar` component instance in `Index.tsx`, allowing it to fall back to the default, functional styles from the base UI component. This should restore the ability to navigate between months freely.