### PR TITLE
Refactor: Address your feedback on booking and progress UI

### DIFF
--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -75,9 +75,14 @@ const Admin = () => {
     });
 
     return activeBookings.map(b => {
-      const progress = progressMap[b.discipline];
-      const percentage = progress ? (progress.actualRecorded / progress.totalUnits) * 100 : 0;
-      return { ...b, disciplineProgress: Math.min(percentage, 100) };
+      const progress = progressMap[b.discipline] || { totalUnits: 0, actualRecorded: 0 };
+      const percentage = progress.totalUnits > 0 ? (progress.actualRecorded / progress.totalUnits) * 100 : 0;
+      return {
+        ...b,
+        disciplineProgress: Math.min(percentage, 100),
+        actualRecorded: progress.actualRecorded,
+        totalUnits: progress.totalUnits
+      };
     });
   }, [bookings]);
 
@@ -96,11 +101,13 @@ const Admin = () => {
       accessorKey: "disciplineProgress",
       header: "Progresso Disciplina",
       cell: ({ row }) => {
-        const percentage = row.original.disciplineProgress;
+        const { disciplineProgress, actualRecorded, totalUnits } = row.original;
         return (
-          <div className="flex items-center gap-2">
-            <Progress value={percentage} className="w-[80%]" />
-            <span className="text-xs text-muted-foreground">{percentage.toFixed(0)}%</span>
+          <div className="relative w-full">
+            <Progress value={disciplineProgress} className="h-5" />
+            <span className="absolute inset-0 flex items-center justify-center text-xs font-medium text-primary-foreground">
+              {actualRecorded}/{totalUnits}
+            </span>
           </div>
         )
       },

--- a/src/pages/Editor.tsx
+++ b/src/pages/Editor.tsx
@@ -180,9 +180,14 @@ const Editor = () => {
     });
 
     return activeBookings.map(b => {
-      const progress = progressMap[b.discipline];
-      const percentage = progress ? (progress.actualRecorded / progress.totalUnits) * 100 : 0;
-      return { ...b, disciplineProgress: Math.min(percentage, 100) };
+      const progress = progressMap[b.discipline] || { totalUnits: 0, actualRecorded: 0 };
+      const percentage = progress.totalUnits > 0 ? (progress.actualRecorded / progress.totalUnits) * 100 : 0;
+      return {
+        ...b,
+        disciplineProgress: Math.min(percentage, 100),
+        actualRecorded: progress.actualRecorded,
+        totalUnits: progress.totalUnits
+      };
     });
   }, [bookings]);
 
@@ -240,12 +245,17 @@ const Editor = () => {
       accessorKey: "disciplineProgress",
       header: "Progresso Disciplina",
       cell: ({ row }) => {
+        const { disciplineProgress, actualRecorded, totalUnits } = row.original;
         const isFirstInDiscipline = ongoingData.findIndex(b => b.discipline === row.original.discipline) === row.index;
 
         return (
           <div className="flex items-center gap-2">
-            <Progress value={row.original.disciplineProgress} className="w-[80%]" />
-            <span className="text-xs text-muted-foreground">{row.original.disciplineProgress.toFixed(0)}%</span>
+            <div className="w-[60%] relative">
+              <Progress value={disciplineProgress} className="h-5" />
+              <span className="absolute inset-0 flex items-center justify-center text-xs font-medium text-primary-foreground">
+                {actualRecorded}/{totalUnits}
+              </span>
+            </div>
             {row.original.allRecordingsDone && isFirstInDiscipline && (
               <>
                 <Tooltip>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -89,7 +89,7 @@ function Index() {
     start: string,
     end: string
   ) => {
-    setForm((f) => ({ ...f, dateISO, period, start, end, teacher: '', course: '', discipline: '', totalUnits: 8 }));
+    setForm((f) => ({ ...f, dateISO, period, start, end, teacher: '', course: '', discipline: '', totalUnits: 8, recordedUnits: 4 }));
     setDisciplineInfo(null);
     setOpen(true);
   };
@@ -319,10 +319,10 @@ function Index() {
                                   <div className="grid items-center gap-4">
                                     <Label htmlFor="totalUnits">Total de Unidades da Disciplina</Label>
                                     <Input id="totalUnits" type="number" value={form.totalUnits} onChange={(e) => setForm({ ...form, totalUnits: Number(e.target.value) })} placeholder="Ex: 8" disabled={!!disciplineInfo} />
-                              </div>
-                               <div className="grid items-center gap-4">
-                                <Label htmlFor="recordedUnits">Aulas a Serem Gravadas</Label>
-                                <Input id="recordedUnits" type="number" value={form.recordedUnits} onChange={(e) => setForm({ ...form, recordedUnits: Number(e.target.value) })} placeholder="Ex: 4" />
+                                  </div>
+                                   <div className="grid items-center gap-4">
+                                    <Label htmlFor="recordedUnits">Aulas a Serem Gravadas</Label>
+                                    <Input id="recordedUnits" type="number" value={form.recordedUnits} onChange={(e) => setForm({ ...form, recordedUnits: Number(e.target.value) })} placeholder="Ex: 4" />
                                     {disciplineInfo && (
                                       <p className="text-sm text-muted-foreground">
                                         Unidades restantes para gravar: {disciplineInfo.remaining} de {disciplineInfo.total}.

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -80,6 +80,7 @@ function Index() {
     course: "",
     discipline: "",
     totalUnits: 8, // Default value
+    recordedUnits: 4, // Default value
   });
 
   const openDialog = (
@@ -118,6 +119,11 @@ function Index() {
       return;
     }
 
+    if (disciplineInfo && form.recordedUnits > disciplineInfo.remaining) {
+       toast({ variant: "destructive", title: "Limite de Aulas Excedido", description: `Você está tentando agendar ${form.recordedUnits} aulas, mas apenas ${disciplineInfo.remaining} estão disponíveis para esta disciplina.` });
+      return;
+    }
+
     if (disciplineInfo && disciplineInfo.remaining <= 0) {
       toast({ variant: "destructive", title: "Disciplina Concluída", description: "Todas as unidades desta disciplina já foram gravadas." });
       return;
@@ -140,7 +146,7 @@ function Index() {
       teacher: form.teacher,
       status: "pendente",
       totalUnits: form.totalUnits,
-      recordedUnits: form.totalUnits / 2, // Grava metade das unidades por agendamento
+      recordedUnits: form.recordedUnits,
     });
     setOpen(false);
     toast({ title: "Reserva realizada!", description: `Agendado para ${format(new Date(form.dateISO.replace(/-/g, '/')), "dd/MM/yyyy")} no período da ${form.period.toLowerCase()}.` });
@@ -313,6 +319,10 @@ function Index() {
                                   <div className="grid items-center gap-4">
                                     <Label htmlFor="totalUnits">Total de Unidades da Disciplina</Label>
                                     <Input id="totalUnits" type="number" value={form.totalUnits} onChange={(e) => setForm({ ...form, totalUnits: Number(e.target.value) })} placeholder="Ex: 8" disabled={!!disciplineInfo} />
+                              </div>
+                               <div className="grid items-center gap-4">
+                                <Label htmlFor="recordedUnits">Aulas a Serem Gravadas</Label>
+                                <Input id="recordedUnits" type="number" value={form.recordedUnits} onChange={(e) => setForm({ ...form, recordedUnits: Number(e.target.value) })} placeholder="Ex: 4" />
                                     {disciplineInfo && (
                                       <p className="text-sm text-muted-foreground">
                                         Unidades restantes para gravar: {disciplineInfo.remaining} de {disciplineInfo.total}.


### PR DESCRIPTION
This commit addresses your feedback to improve the booking creation process and the clarity of the progress bar UI.

- **Flexible Booking:** The booking creation form on the Index page now allows you to specify the exact number of lessons to be recorded for a given session. The previous logic that automatically scheduled half of the total units has been removed. Validation has been added to prevent scheduling more lessons than are available for the discipline.

- **Improved Progress Bar:** The discipline progress bar in both the Editor and Admin views has been enhanced. It now displays the raw progress numbers (e.g., "4/8") as text inside the bar, providing a clearer and more immediate understanding of the recording status than the previous percentage-based display.