### PR TITLE
fix: Refactor useUpdateDiscipline hook to use mock API

### DIFF
--- a/src/hooks/api/useUpdateDiscipline.ts
+++ b/src/hooks/api/useUpdateDiscipline.ts
@@ -1,39 +1,18 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { Booking } from '@/context/BookingsContext';
+import { updateDisciplineAPI } from '@/lib/api';
 
 type DisciplineUpdatePayload = {
   disciplineName: string;
   patch: Partial<Booking>;
 };
 
-// This function simulates a bulk update on all bookings for a given discipline.
-const updateDisciplineAPI = async ({ disciplineName, patch }: DisciplineUpdatePayload): Promise<void> => {
-  console.log(`Updating all bookings for discipline ${disciplineName} on the API...`, patch);
-  await new Promise(resolve => setTimeout(resolve, 300));
-
-  const rawData = localStorage.getItem("ead-bookings-v1");
-  let bookings: Booking[] = rawData ? JSON.parse(rawData) : [];
-
-  bookings = bookings.map(b => {
-    if (b.discipline === disciplineName) {
-      // For reverting, we need to remove a property, not just patch.
-      if ('completionDate' in patch && patch.completionDate === null) {
-        const { completionDate, ...rest } = b;
-        return { ...rest, ...patch };
-      }
-      return { ...b, ...patch };
-    }
-    return b;
-  });
-
-  localStorage.setItem("ead-bookings-v1", JSON.stringify(bookings));
-};
-
 export const useUpdateDiscipline = () => {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: updateDisciplineAPI,
+    mutationFn: ({ disciplineName, patch }: DisciplineUpdatePayload) =>
+      updateDisciplineAPI(disciplineName, patch),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['bookings'] });
     },

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -61,3 +61,17 @@ export const removeBookingAPI = async (id: string): Promise<void> => {
   });
   await handleResponse<void>(response);
 };
+
+/**
+ * Updates all bookings for a given discipline.
+ */
+export const updateDisciplineAPI = async (disciplineName: string, patch: Partial<Booking>): Promise<void> => {
+  const response = await fetch(`${API_BASE_URL}/disciplines/${encodeURIComponent(disciplineName)}`, {
+    method: 'PATCH',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(patch),
+  });
+  await handleResponse<void>(response);
+};

--- a/src/mocks/db.ts
+++ b/src/mocks/db.ts
@@ -72,4 +72,19 @@ export const db = {
     bookings.splice(index, 1);
     return true;
   },
+  updateBookingsByDiscipline: (disciplineName: string, patch: Partial<Booking>) => {
+    const updatedBookings = bookings.map(b => {
+      if (b.discipline === disciplineName) {
+        // Handle special case for reverting completion by removing a property
+        if ('completionDate' in patch && patch.completionDate === undefined) {
+          const { completionDate, ...rest } = b;
+          return { ...rest, ...patch };
+        }
+        return { ...b, ...patch };
+      }
+      return b;
+    });
+    bookings.length = 0;
+    bookings.push(...updatedBookings);
+  },
 };

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -74,4 +74,19 @@ export const handlers = [
       { status: 401, headers: { 'Content-Type': 'application/json' } }
     )
   }),
+
+  // Handle bulk update for a discipline
+  http.patch(`${API_PREFIX}/disciplines/:disciplineName`, async ({ request, params }) => {
+    const { disciplineName } = params;
+    const patch = await request.json() as Partial<Booking>;
+
+    if (typeof disciplineName !== 'string') {
+      return new HttpResponse(null, { status: 400 });
+    }
+
+    const decodedDisciplineName = decodeURIComponent(disciplineName);
+    db.updateBookingsByDiscipline(decodedDisciplineName, patch);
+
+    return new HttpResponse(null, { status: 204 });
+  }),
 ]


### PR DESCRIPTION
This commit fixes a bug where the 'Finalizar Gravações' button in the Editor view would cause state inconsistencies, leading to subsequent 404 errors.

The root cause was that the `useUpdateDiscipline` hook was still using `localStorage` to update booking data, while the rest of the application had been migrated to use a `react-query` and MSW-based mock API. This created a state mismatch.

The following changes were made to resolve this:
- Added a new mock API endpoint `PATCH /api/disciplines/:disciplineName` to `src/mocks/handlers.ts` for bulk-updating bookings of a specific discipline.
- Added a corresponding `updateBookingsByDiscipline` function to the in-memory database at `src/mocks/db.ts`.
- Added a new `updateDisciplineAPI` function to `src/lib/api.ts` to make `fetch` calls to the new endpoint.
- Refactored `src/hooks/api/useUpdateDiscipline.ts` to remove all `localStorage` logic and use the new `updateDisciplineAPI` function through `useMutation`.