### PR TITLE
feat: Add edit functionality for bookings on Index page

### DIFF
--- a/src/components/index/BookingActions.tsx
+++ b/src/components/index/BookingActions.tsx
@@ -14,6 +14,7 @@ import { Booking } from "@/context/BookingsContext";
 import { useRemoveBooking } from "@/hooks/api/useRemoveBooking";
 import { Link2, Send, Trash2 } from "lucide-react";
 import { toast } from "sonner";
+import { EditBookingDialog } from "./EditBookingDialog";
 
 interface BookingActionsProps {
   booking: Booking;
@@ -58,6 +59,7 @@ export function BookingActions({ booking }: BookingActionsProps) {
       >
         <Send className="h-4 w-4" />
       </Button>
+      <EditBookingDialog booking={booking} />
       <AlertDialog>
         <AlertDialogTrigger asChild>
           <Button

--- a/src/components/index/EditBookingDialog.tsx
+++ b/src/components/index/EditBookingDialog.tsx
@@ -1,0 +1,102 @@
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { useUpdateBooking } from "@/hooks/api/useUpdateBooking";
+import { toast } from "sonner";
+import { Loader2, Pencil } from "lucide-react";
+import { Booking } from "@/context/BookingsContext";
+
+interface EditBookingDialogProps {
+  booking: Booking;
+}
+
+export function EditBookingDialog({ booking }: EditBookingDialogProps) {
+  const updateBookingMutation = useUpdateBooking();
+
+  const [open, setOpen] = useState(false);
+  const [form, setForm] = useState({
+    teacher: booking.teacher,
+    course: booking.course,
+    discipline: booking.discipline,
+  });
+
+  const submit = () => {
+    if (!form.teacher || !form.course || !form.discipline) {
+      toast.error("Todos os campos são obrigatórios.");
+      return;
+    }
+
+    updateBookingMutation.mutate(
+      {
+        id: booking.id,
+        patch: {
+          teacher: form.teacher,
+          course: form.course,
+          discipline: form.discipline,
+        },
+      },
+      {
+        onSuccess: () => {
+          setOpen(false);
+          toast.success("Agendamento atualizado com sucesso!");
+        },
+        onError: () => {
+          toast.error("Falha ao atualizar", {
+            description: "Ocorreu um erro. Tente novamente.",
+          });
+        },
+      }
+    );
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-8 w-8"
+          title="Editar agendamento"
+        >
+          <Pencil className="h-4 w-4" />
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>
+            Editar Agendamento
+          </DialogTitle>
+        </DialogHeader>
+        <div className="grid gap-4 py-4">
+          <div className="grid items-center gap-4">
+            <Label htmlFor="teacher">Docente</Label>
+            <Input id="teacher" value={form.teacher} onChange={(e) => setForm({ ...form, teacher: e.target.value })} placeholder="Nome do docente" />
+          </div>
+          <div className="grid items-center gap-4">
+            <Label htmlFor="course">Curso</Label>
+            <Input id="course" value={form.course} onChange={(e) => setForm({ ...form, course: e.target.value })} placeholder="Ex: Administração" />
+          </div>
+          <div className="grid items-center gap-4">
+            <Label htmlFor="discipline">Disciplina</Label>
+            <Input id="discipline" value={form.discipline} onChange={(e) => setForm({ ...form, discipline: e.target.value })} placeholder="Ex: Marketing I" />
+          </div>
+        </div>
+        <div className="flex justify-end gap-2">
+          <Button variant="outline" onClick={() => setOpen(false)}>Cancelar</Button>
+          <Button onClick={submit} disabled={updateBookingMutation.isPending}>
+            {updateBookingMutation.isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+            Salvar Alterações
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/mocks/db.ts
+++ b/src/mocks/db.ts
@@ -76,9 +76,12 @@ export const db = {
     const updatedBookings = bookings.map(b => {
       if (b.discipline === disciplineName) {
         // Handle special case for reverting completion by removing a property
-        if ('completionDate' in patch && patch.completionDate === undefined) {
+        if (patch.completionDate === null) {
           const { completionDate, ...rest } = b;
-          return { ...rest, ...patch };
+          // Create a new patch without completionDate to avoid re-adding it as null
+          const newPatch = { ...patch };
+          delete newPatch.completionDate;
+          return { ...rest, ...newPatch };
         }
         return { ...b, ...patch };
       }

--- a/src/pages/Editor.tsx
+++ b/src/pages/Editor.tsx
@@ -136,7 +136,7 @@ const Editor = () => {
   const handleRevertCompletion = (disciplineName: string) => {
     updateDisciplineMutation.mutate({
       disciplineName,
-      patch: { completionDate: undefined }
+      patch: { completionDate: null } // Use null to ensure it's serialized in JSON
     });
   };
 


### PR DESCRIPTION
This commit introduces a new feature allowing users to edit the details of an existing booking directly from the main calendar (Index) page.

- An 'Edit' button has been added to the actions for a booked time slot.
- Clicking the button opens a new `EditBookingDialog` which comes pre-filled with the booking's current information (teacher, course, discipline).
- On saving, the form calls the `useUpdateBooking` hook to persist the changes.

fix: Correctly handle revert completion functionality

This commit also fixes a bug where the 'Revert' button on the Editor page was not working correctly.

- The issue was caused by `undefined` being stripped from the JSON payload when making the API call. The logic has been changed to use `null` instead.
- The mock database (`db.ts`) has been updated to correctly handle the `null` value and remove the `completionDate` property from the booking, effectively reverting its status.