### PR TITLE
fix: Correct mutate call signature in Header notifications

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -103,9 +103,9 @@ const Header = () => {
                       const isEditorCancellation = b.editorCancelled && !b.editorCancellationRead;
 
                       const handleSelect = () => {
-                        if (isUpload) updateBookingMutation.mutate({ id: b.id, uploadNotificationRead: true });
-                        if (isTeacherCancellation) updateBookingMutation.mutate({ id: b.id, cancellationRead: true });
-                        if (isEditorCancellation) updateBookingMutation.mutate({ id: b.id, editorCancellationRead: true });
+                        if (isUpload) updateBookingMutation.mutate({ id: b.id, patch: { uploadNotificationRead: true } });
+                        if (isTeacherCancellation) updateBookingMutation.mutate({ id: b.id, patch: { cancellationRead: true } });
+                        if (isEditorCancellation) updateBookingMutation.mutate({ id: b.id, patch: { editorCancellationRead: true } });
                       }
 
                       return (
@@ -178,8 +178,8 @@ const Header = () => {
                       const isCancellation = (b.teacherConfirmation === "NEGADO" || b.status === "cancelado") && !b.cancellationReadByEditor;
 
                       const handleSelect = () => {
-                        if (isUpload) updateBookingMutation.mutate({ id: b.id, uploadNotificationRead: true });
-                        if (isCancellation) updateBookingMutation.mutate({ id: b.id, cancellationReadByEditor: true });
+                        if (isUpload) updateBookingMutation.mutate({ id: b.id, patch: { uploadNotificationRead: true } });
+                        if (isCancellation) updateBookingMutation.mutate({ id: b.id, patch: { cancellationReadByEditor: true } });
                       };
 
                       return (


### PR DESCRIPTION
This commit fixes a bug that caused a 500 error when clicking on a notification in the Header component.

The `useUpdateBooking` mutation hook expects its payload to be in the format `{ id: string, patch: object }`. The `handleSelect` function in the notifications dropdown was calling `mutate` with a flat object, like `{ id: string, ...patch }`.

This caused the mock API handler to receive a request with a malformed body, leading to a JSON parsing error and a 500 response.

The `mutate` calls in `Header.tsx` for both admin and editor notifications have been corrected to wrap the update data in a `patch` object, aligning with the hook's expected signature.