### PR TITLE
fix: Add validation for lessons recorded in editor dialog

### DIFF
--- a/src/components/editor/EditDetailsDialog.tsx
+++ b/src/components/editor/EditDetailsDialog.tsx
@@ -9,12 +9,13 @@ import {
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
-import { Booking } from "@/context/BookingsContext";
+import { BookingWithProgress } from "@/context/BookingsContext";
 import { useState } from "react";
+import { toast } from "sonner";
 
 interface EditDetailsDialogProps {
-  booking: Booking;
-  onSave: (data: Partial<Booking>) => void;
+  booking: BookingWithProgress;
+  onSave: (data: Partial<BookingWithProgress>) => void;
 }
 
 export function EditDetailsDialog({ booking, onSave }: EditDetailsDialogProps) {
@@ -24,6 +25,23 @@ export function EditDetailsDialog({ booking, onSave }: EditDetailsDialogProps) {
   });
 
   const handleSave = () => {
+    const { totalUnits, actualRecorded } = booking;
+    const originalLessonsForThisBooking = booking.lessonsRecorded ?? 0;
+
+    // The total recorded by OTHER bookings is the cumulative total minus this booking's original contribution.
+    const lessonsRecordedByOthers = actualRecorded - originalLessonsForThisBooking;
+
+    // The maximum number of lessons the user can record in this session is the total for the discipline
+    // minus what has already been recorded by other bookings.
+    const maxLessonsAllowed = totalUnits - lessonsRecordedByOthers;
+
+    if (formData.lessonsRecorded > maxLessonsAllowed) {
+      toast.error("Limite de aulas excedido", {
+        description: `Você está tentando gravar ${formData.lessonsRecorded} aulas, mas o limite para este agendamento é de ${maxLessonsAllowed} para não ultrapassar o total de ${totalUnits} da disciplina.`,
+      });
+      return;
+    }
+
     onSave(formData);
   };
 


### PR DESCRIPTION
This commit adds input validation to the 'Edit Details' dialog on the Editor page.

Previously, it was possible for an editor to enter a number for 'lessons recorded' that would cause the total number of recorded lessons for a discipline to exceed its `totalUnits`.

This change introduces a check that calculates the maximum number of lessons that can be recorded for a specific booking without exceeding the discipline's total. If the user enters a number greater than this limit, an error toast is displayed, and the save is prevented.

This aligns the behavior of the editor's edit dialog with the validation already present in the new booking dialog.