### PR TITLE
feat: Add teacher column to Admin and Editor tables

### DIFF
--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -88,6 +88,7 @@ const Admin = () => {
       header: "Horário",
       cell: ({ row }) => `${row.original.start} - ${row.original.end}`,
     },
+    { accessorKey: "teacher", header: "Docente" },
     { accessorKey: "course", header: "Curso" },
     { accessorKey: "discipline", header: "Disciplina" },
     { accessorKey: "recordedUnits", header: "Aulas Agendadas" },

--- a/src/pages/Editor.tsx
+++ b/src/pages/Editor.tsx
@@ -176,6 +176,7 @@ const Editor = () => {
       header: "Horário",
       cell: ({ row }) => `${row.original.start} - ${row.original.end}`,
     },
+    { accessorKey: "teacher", header: "Docente" },
     { accessorKey: "course", header: "Curso" },
     { accessorKey: "discipline", header: "Disciplina" },
     { accessorKey: "lessonsRecorded", header: "Aulas Gravadas" },


### PR DESCRIPTION
I have added the 'Docente' (teacher) column to the main tables in both the Admin and Editor pages, as you requested.

- In `src/pages/Editor.tsx`, the `ongoingColumns` definition now includes an `accessorKey` for `teacher`.
- In `src/pages/Admin.tsx`, the `columns` definition now includes an `accessorKey` for `teacher`.

This provides better visibility of key information in the main data tables.