### PR TITLE
fix(css): Correct calendar styling for today's date in dark mode

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -111,7 +111,7 @@ function Index() {
                   cell: "h-12 w-12 text-center text-lg p-0 relative [&:has([aria-selected])]:bg-accent first:[&:has([aria-selected])]:rounded-l-md last:[&:has([aria-selected])]:rounded-r-md focus-within:relative focus-within:z-20",
                   day: "h-12 w-12 p-0 font-normal aria-selected:opacity-100 rounded-full hover:bg-accent/50 transition-colors",
                   day_selected: "bg-primary text-primary-foreground rounded-full hover:bg-primary hover:text-primary-foreground focus:bg-primary focus:text-primary-foreground",
-                  day_today: "bg-accent text-accent-foreground rounded-full",
+                  day_today: "bg-transparent border border-primary rounded-full",
                   day_outside: "text-muted-foreground opacity-50",
                   day_disabled: "text-muted-foreground opacity-50",
                   day_range_middle: "aria-selected:bg-accent aria-selected:text-accent-foreground",


### PR DESCRIPTION
This commit fixes a visual bug in the Calendar component on the Index page.

Previously, when a day was both 'today' and 'selected' in dark mode, a square background color (`bg-accent`) would appear behind the circular primary color, creating an undesirable visual effect.

The `day_today` class in the Calendar's `classNames` prop has been changed from using `bg-accent` to using a transparent background with a border (`bg-transparent border border-primary`). This provides a subtle indicator for the current day without conflicting with the 'selected' day style.