### PR TITLE
feat(filters): Implementa filtros e melhorias nas notificações

### DIFF
--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -43,10 +43,13 @@ const Admin = () => {
 
   const data = useMemo<BookingWithProgress[]>(() => {
     if (!bookings) return [];
+
+    const activeBookings = bookings.filter(b => b.teacherConfirmation !== 'NEGADO' && b.status !== 'cancelado');
+
     // The data processing logic can be simpler for admin, as we don't need cumulative progress.
     // We just need the final total for each discipline.
     const progressMap: Record<string, { totalUnits: number; actualRecorded: number }> = {};
-    bookings.forEach(b => {
+    activeBookings.forEach(b => {
       if (!b.discipline || !b.totalUnits) return;
       if (!progressMap[b.discipline]) {
         progressMap[b.discipline] = { totalUnits: b.totalUnits, actualRecorded: 0 };
@@ -54,7 +57,7 @@ const Admin = () => {
       progressMap[b.discipline].actualRecorded += b.lessonsRecorded ?? b.recordedUnits ?? 0;
     });
 
-    return bookings.map(b => {
+    return activeBookings.map(b => {
       const progress = progressMap[b.discipline] || { totalUnits: 0, actualRecorded: 0 };
       const percentage = progress.totalUnits > 0 ? (progress.actualRecorded / progress.totalUnits) * 100 : 0;
       return {

--- a/src/pages/Editor.tsx
+++ b/src/pages/Editor.tsx
@@ -118,15 +118,27 @@ const Editor = () => {
     });
   };
   const handleCancelBooking = (bookingId: string, reason: string) => {
+    const booking = bookings.find(b => b.id === bookingId);
+    if (!booking) return;
+
     updateBookingMutation.mutate({
       id: bookingId,
       patch: {
         status: 'cancelado',
         cancellationReason: reason,
-        editorCancellationRead: false
+        editorCancelled: true,
+        editorCancellationRead: false, // This flag is for the admin to mark as read
       }
     }, {
-      onSuccess: () => { toast.success("Agendamento cancelado com sucesso."); }
+      onSuccess: () => {
+        toast.success("Agendamento cancelado com sucesso.");
+        localStorage.setItem('new-notification', JSON.stringify({
+          recipient: 'admin',
+          title: 'Cancelado pelo Editor',
+          message: `O agendamento para ${booking.discipline} foi cancelado.`,
+          reason: reason
+        }));
+      }
     });
   };
   const handleRevertCompletion = (disciplineName: string) => {


### PR DESCRIPTION
Este commit introduz várias melhorias nos filtros e no sistema de notificações.

- **Filtros de Agendamento:**
  - As visualizações do Admin (`Admin.tsx`) agora ocultam agendamentos que foram cancelados ou recusados pelo docente. As outras visualizações relevantes já possuíam este filtro.

- **Cancelamento pelo Admin:**
  - O modal de cancelamento do Admin agora inclui um campo opcional para especificar o motivo do cancelamento.
  - Este motivo é salvo e exibido na notificação enviada ao Editor.

- **Notificações em Tempo Real:**
  - O sistema de notificações foi aprimorado para ser "em tempo real" entre abas abertas no mesmo navegador.
  - Quando um Admin ou Editor cancela um agendamento, uma notificação via `toast` aparece instantaneamente para o outro usuário, se ele estiver com o sistema aberto.
  - Isso é implementado usando um `localStorage` event listener no componente `Header`.